### PR TITLE
adding failing tests

### DIFF
--- a/factorio-core/src/test/scala/factorio/SubclassingSpec.scala
+++ b/factorio-core/src/test/scala/factorio/SubclassingSpec.scala
@@ -1,0 +1,41 @@
+package factorio
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SubclassingSpec extends AnyFlatSpec with Matchers {
+
+  val counter = new AtomicInteger(1)
+
+  trait Thing
+
+  class RealThing extends Thing {
+    private val id = counter.getAndIncrement()
+
+    override def toString: String = s"RealThing($id)"
+
+  }
+
+  class WantSomething(
+    val some: Thing,
+    val real: RealThing
+  )
+
+  @blueprint
+  class TestBlueprint {
+
+    @provides
+    def thing: Thing = new RealThing // kind of an equivalent for @binds[Thing to RealThing]
+  }
+
+  "Assembly macro" should "bind `some: Thing` and `real: RealThing` to the provided instance of `RealThing`" in {
+
+    val assembler = Assembler[WantSomething](new TestBlueprint)
+    val assembled = assembler()
+
+    assert(assembled.some == assembled.real)
+  }
+
+}

--- a/factorio-core/src/test/scala/factorio/WeirdCaseSpec.scala
+++ b/factorio-core/src/test/scala/factorio/WeirdCaseSpec.scala
@@ -1,0 +1,37 @@
+package factorio
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+object WeirdCaseDomain {
+
+  trait Thing1
+  class RealThing1 extends Thing1
+
+  class WantSomething(
+    val some: Thing1
+  )
+
+}
+
+class WeirdCaseSpec extends AnyFlatSpec with Matchers {
+
+  import WeirdCaseDomain._
+
+  @blueprint
+  class TestBlueprint {
+
+    @provides
+    def thing: Thing1 = new RealThing1
+  }
+
+  "Assembly macro" should "assemble a component" in {
+
+//    compilation fails if uncommented
+//    val assembler = Assembler[WantSomething](new TestBlueprint)
+//    assembler()
+
+    succeed
+  }
+
+}

--- a/factorio-core/src/test/scala/factorio/WeirdCaseSpec.scala
+++ b/factorio-core/src/test/scala/factorio/WeirdCaseSpec.scala
@@ -5,11 +5,11 @@ import org.scalatest.matchers.should.Matchers
 
 object WeirdCaseDomain {
 
-  trait Thing1
-  class RealThing1 extends Thing1
+  trait Thing
+  class RealThing extends Thing
 
   class WantSomething(
-    val some: Thing1
+    val some: Thing
   )
 
 }
@@ -22,7 +22,7 @@ class WeirdCaseSpec extends AnyFlatSpec with Matchers {
   class TestBlueprint {
 
     @provides
-    def thing: Thing1 = new RealThing1
+    def thing: Thing = new RealThing
   }
 
   "Assembly macro" should "assemble a component" in {


### PR DESCRIPTION
`SubclassingSpec` I'm not sure if it's supposed to work like this, but I was expecting it :)

`WeirdCaseSpec`  it fails like this (if the code is uncommented):

```text
[error]  [Factorio]: Cannot construct an instance of an abstract class [factorio.WeirdCaseDomain.Thing], provide a concrete class binder or an instance provider.
[error]
[error] While analyzing path:
[error] 0: factorio.WeirdCaseDomain.WantSomething ->
[error]
[error]     val assembler = Assembler[WantSomething](new TestBlueprint)
```

but the `Thing` is bound:
```
    @provides
    def thing: Thing = new RealThing
```